### PR TITLE
Ignore hash part of the URL

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,6 +4,11 @@ function abbreviatedUrl(tab) {
   return tab.url.length > 30 ? tab.url.match(/^.{15}|.{15}$/g).join('...') : tab.url;
 }
 
+function compareUrls(left, right) {
+  console.log(left, right);
+  return left.replace(/#.*$/, "") == right.replace(/#.*$/, "");
+}
+
 function onCompleted(details) {
   if (details.frameId == 0 && details.url && details.url != '' && !details.url.match(/^chrome:\/\//)) {
     chrome.tabs.get(details.tabId, function(tab) {
@@ -12,7 +17,7 @@ function onCompleted(details) {
 
       chrome.tabs.getAllInWindow(tab.windowId, function(tabs) {
         var duplicates = tabs.filter(function(t) {
-          return t.url == details.url && t.id != tab.id && !t.pinned && t.status == 'complete';
+          return compareUrls(t.url, details.url) && t.id != tab.id && !t.pinned && t.status == 'complete';
         });
         if (duplicates.length) {
           removeDuplicates(tab, duplicates);

--- a/background.js
+++ b/background.js
@@ -5,7 +5,6 @@ function abbreviatedUrl(tab) {
 }
 
 function compareUrls(left, right) {
-  console.log(left, right);
   return left.replace(/#.*$/, "") == right.replace(/#.*$/, "");
 }
 


### PR DESCRIPTION
This is particularly important for Google Docs urls but also helps with a bunch of other sites and single page apps.